### PR TITLE
HTMLファイル名ではなく、独自のルーティングを可能にする

### DIFF
--- a/nginx_web_server/config/default.conf
+++ b/nginx_web_server/config/default.conf
@@ -16,7 +16,7 @@ server {
         try_files /users.html =404;
     }
 
-    #error_page  404              /404.html;
+    error_page 404 /404.html;
 
     # redirect server error pages to the static page /50x.html
     #

--- a/nginx_web_server/config/default.conf
+++ b/nginx_web_server/config/default.conf
@@ -11,6 +11,11 @@ server {
         index  index.html index.htm;
     }
 
+    location /user_post {
+        root /usr/share/nginx/html;
+        try_files /users.html =404;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html

--- a/nginx_web_server/config/default.conf
+++ b/nginx_web_server/config/default.conf
@@ -11,7 +11,7 @@ server {
         index  index.html index.htm;
     }
 
-    location /user_post {
+    location = /user_post {
         root /usr/share/nginx/html;
         try_files /users.html =404;
     }

--- a/nginx_web_server/html/404.html
+++ b/nginx_web_server/html/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Page Not Foud</title>
+</head>
+<body>
+  <h1>404 Page Not Foud</h1>
+  <h2>申し訳ありません、ページが存在しないようです。</h2>
+</body>
+</html>


### PR DESCRIPTION
## 対応するissue
- #3 

## 詳細
- 独自のルーティングを可能にしました。
- 404ページを作成し、ルーティングしました。
- `/user_post`を設定し、指定のURLパスが完全に一致する場合にのみコンテンツを返すようにしました。
  - locationで`=`を使えばよかった。

## 参考にしたサイト
- https://qiita.com/morrr/items/7c97f0d2e46f7a8ec967#%E3%82%A8%E3%82%A4%E3%83%AA%E3%82%A2%E3%82%B9%E3%82%92%E6%8C%87%E5%AE%9A%E3%81%99%E3%82%8B

## 動作確認
<img width="723" alt="スクリーンショット 2023-07-13 18 33 22" src="https://github.com/ok-os-job-change-team/shoichi-docker-bootcamp/assets/118090073/015c8798-d97b-4ce0-8959-a1b7f7887bf7">
